### PR TITLE
GIT_PARENT_DIR fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ jupyter nbextension enable --py githubcommit
 ## Steps
 
 * Install package using above commands
-* Create Git repo where notebooks will be pushed if not already exists and clone it in home directory
-* Clone this repo as well in home directory
+* Create Git repo where notebooks will be pushed if not already exists and clone it in your `GIT_PARENT_DIR`
+* Clone this repo as well in your `GIT_PARENT_DIR` directory
 * Replace the values in env.sh present in this repo itself
 * Run the command - source ~/githubcommit/env.sh
 * Configure ssh key (present in ~/.ssh/id_rsa.pub or specified location) in github account

--- a/env.sh
+++ b/env.sh
@@ -23,7 +23,7 @@ export GIT_REMOTE_UPSTREAM=$GIT_USER_UPSTREAM/$GIT_REPO_NAME
 
 
 ####################### Git Repo where notebooks will be pushed ############
-cd ~ && git clone $GIT_REMOTE_URL_HTTPS
+cd $GIT_PARENT_DIR && git clone $GIT_REMOTE_URL_HTTPS
 
 
 
@@ -34,4 +34,4 @@ fi
 
 echo 'c.NotebookApp.disable_check_xsrf = True' >> ~/.jupyter/jupyter_notebook_config.py
 
-cp ~/githubcommit/config ~/.ssh/config
+cp $GIT_PARENT_DIR/githubcommit/config ~/.ssh/config

--- a/githubcommit/handlers.py
+++ b/githubcommit/handlers.py
@@ -54,7 +54,7 @@ class GitCommitHandler(IPythonHandler):
         # commit current notebook
         # client will sent pathname containing git directory; append to git directory's parent
         try:
-            print(repo.git.add(str(os.path.expanduser('~') + "/" + os.environ.get('GIT_REPO_NAME') + filename)))
+            print(repo.git.add(str(os.environ.get('GIT_PARENT_DIR') + "/" + os.environ.get('GIT_REPO_NAME') + filename)))
             print(repo.git.commit( a=True, m="{}\n\nUpdated {}".format(msg, filename) ))
         except GitCommandError as e:
             print(e)


### PR DESCRIPTION
Hi there, I really appreciated the concept of this plugin, not being able to interact with Github from Jupyter was bothering me a bit.

I noticed the `GIT_PARENT_DIR` from `env.sh` actually not really used and since I don't clone my repositories in my home directory directly, I decided to fix this :)

## Found Bug
`GIT_PARENT_DIR` setting  ignored

## Way to reproduce it
Try any other value than `~` for `GIT_PARENT_DIR`

## Fix
Replaced the places where `~` was hard-coded and put `GIT_PARENT_DIR` instead.

Cheers